### PR TITLE
Feat: pubblesCategories (게시글 카테고리) API 및 엔티티 구현

### DIFF
--- a/data.erd.json
+++ b/data.erd.json
@@ -4,8 +4,8 @@
   "settings": {
     "width": 3000,
     "height": 3000,
-    "scrollTop": -1243.7674,
-    "scrollLeft": -1082.4048,
+    "scrollTop": -1577.9345,
+    "scrollLeft": -667.5718,
     "zoomLevel": 0.72,
     "show": 431,
     "database": 4,
@@ -46,7 +46,6 @@
     ],
     "relationshipIds": [
       "dWvGyLzm9atVzKQzFvZlo",
-      "41hPCzcaWCLppSbMXwHHM",
       "5p3Q5470oISRC2E0VJPBR",
       "dD_GzBp3_FyN1ahkYqEog",
       "TLUjDwdvJfvROW--vTRa3",
@@ -60,7 +59,8 @@
       "5VQ8I3p-w9jmiI9T439GH",
       "iBS8b-BYcHi3J8OpFXYxP",
       "V9er3BbLiRJ1ijFJRkZlX",
-      "wjd8PJY1UCEqQL9IHACCV"
+      "wjd8PJY1UCEqQL9IHACCV",
+      "YZr5yLlh93phj1l3r3BAY"
     ],
     "indexIds": [],
     "memoIds": []
@@ -108,6 +108,7 @@
         "columnIds": [
           "E-xFy9--Bllgr1WONHJoe",
           "A72SlfYFT0BRzDQshmQZz",
+          "fP7eV5JMjJsckudSiYifa",
           "yUnQKHsra0OozqtCrp3yX",
           "6qsKmlVJCMVIRiaDgKaGe",
           "UOoAxlevf80VPxsLuAf9t",
@@ -116,6 +117,7 @@
         "seqColumnIds": [
           "E-xFy9--Bllgr1WONHJoe",
           "A72SlfYFT0BRzDQshmQZz",
+          "fP7eV5JMjJsckudSiYifa",
           "VTIgZvKLMaAeYzG3B3isA",
           "yUnQKHsra0OozqtCrp3yX",
           "6qsKmlVJCMVIRiaDgKaGe",
@@ -131,14 +133,14 @@
           "color": ""
         },
         "meta": {
-          "updateAt": 1754492632853,
+          "updateAt": 1754822672496,
           "createAt": 1754289304439
         }
       },
       "D-Rb2sNjpk0YacoJTRVdK": {
         "id": "D-Rb2sNjpk0YacoJTRVdK",
-        "name": "PostTag",
-        "comment": "게시글 태그",
+        "name": "PostsCategories",
+        "comment": "게시글 카테고리",
         "columnIds": [
           "teo1Mv1wYgKO8-7zwxC4n",
           "4ux9T7A_p2AlRyfhl8W4F",
@@ -154,12 +156,12 @@
           "x": 788.3834,
           "y": 2203.568,
           "zIndex": 207,
-          "widthName": 60,
-          "widthComment": 60,
+          "widthName": 95,
+          "widthComment": 78,
           "color": ""
         },
         "meta": {
-          "updateAt": 1754492632853,
+          "updateAt": 1754822504962,
           "createAt": 1754289838470
         }
       },
@@ -753,7 +755,7 @@
         "default": "",
         "options": 8,
         "ui": {
-          "keys": 2,
+          "keys": 0,
           "widthName": 60,
           "widthComment": 60,
           "widthDataType": 60,
@@ -1783,6 +1785,26 @@
           "updateAt": 1754292220839,
           "createAt": 1754292152312
         }
+      },
+      "fP7eV5JMjJsckudSiYifa": {
+        "id": "fP7eV5JMjJsckudSiYifa",
+        "tableId": "qRUdZZ0mToHT-_20zMDjK",
+        "name": "postsCategories_id",
+        "comment": "",
+        "dataType": "STRING",
+        "default": "",
+        "options": 8,
+        "ui": {
+          "keys": 2,
+          "widthName": 112,
+          "widthComment": 60,
+          "widthDataType": 60,
+          "widthDefault": 60
+        },
+        "meta": {
+          "updateAt": 1754822687873,
+          "createAt": 1754822670012
+        }
       }
     },
     "relationshipEntities": {
@@ -1796,50 +1818,22 @@
           "columnIds": [
             "BiderUKU6fxp0y8QcukEM"
           ],
-          "x": 1243.262,
-          "y": 1511.9108,
-          "direction": 8
+          "x": 1150.762,
+          "y": 1461.9108,
+          "direction": 1
         },
         "end": {
           "tableId": "qRUdZZ0mToHT-_20zMDjK",
           "columnIds": [
             "A72SlfYFT0BRzDQshmQZz"
           ],
-          "x": 1267.2872,
-          "y": 1752.7162,
-          "direction": 2
+          "x": 1196.0372,
+          "y": 1702.7162,
+          "direction": 4
         },
         "meta": {
           "updateAt": 1754289523167,
           "createAt": 1754289523167
-        }
-      },
-      "4TzGNTzc6Zd4ArK5411NU": {
-        "id": "4TzGNTzc6Zd4ArK5411NU",
-        "identification": false,
-        "relationshipType": 16,
-        "startRelationshipType": 2,
-        "start": {
-          "tableId": "qRUdZZ0mToHT-_20zMDjK",
-          "columnIds": [
-            "E-xFy9--Bllgr1WONHJoe"
-          ],
-          "x": 431.8333,
-          "y": 726.8332,
-          "direction": 8
-        },
-        "end": {
-          "tableId": "D-Rb2sNjpk0YacoJTRVdK",
-          "columnIds": [
-            "afg-0wrgBcFjGGFZF588j"
-          ],
-          "x": 311.5,
-          "y": 917.0005,
-          "direction": 4
-        },
-        "meta": {
-          "updateAt": 1754289891923,
-          "createAt": 1754289891923
         }
       },
       "41hPCzcaWCLppSbMXwHHM": {
@@ -1870,34 +1864,6 @@
           "createAt": 1754289924072
         }
       },
-      "Vv_mksqLY6rsReQ4JZGoj": {
-        "id": "Vv_mksqLY6rsReQ4JZGoj",
-        "identification": false,
-        "relationshipType": 16,
-        "startRelationshipType": 2,
-        "start": {
-          "tableId": "qRUdZZ0mToHT-_20zMDjK",
-          "columnIds": [
-            "E-xFy9--Bllgr1WONHJoe"
-          ],
-          "x": 536.8333,
-          "y": 726.8332,
-          "direction": 8
-        },
-        "end": {
-          "tableId": "M2Io9OUdRcGf9qPYHL0Ez",
-          "columnIds": [
-            "5pb6A-aIOIvdjiWbe7qrr"
-          ],
-          "x": 638,
-          "y": 1026.0005,
-          "direction": 1
-        },
-        "meta": {
-          "updateAt": 1754289986359,
-          "createAt": 1754289986359
-        }
-      },
       "5p3Q5470oISRC2E0VJPBR": {
         "id": "5p3Q5470oISRC2E0VJPBR",
         "identification": false,
@@ -1909,7 +1875,7 @@
             "E-xFy9--Bllgr1WONHJoe"
           ],
           "x": 847.2872,
-          "y": 1802.7162,
+          "y": 1814.7162,
           "direction": 1
         },
         "end": {
@@ -2010,34 +1976,6 @@
           "createAt": 1754290271926
         }
       },
-      "KaYv9M3c1yLBphL7TqxCf": {
-        "id": "KaYv9M3c1yLBphL7TqxCf",
-        "identification": false,
-        "relationshipType": 16,
-        "startRelationshipType": 2,
-        "start": {
-          "tableId": "qRUdZZ0mToHT-_20zMDjK",
-          "columnIds": [
-            "E-xFy9--Bllgr1WONHJoe"
-          ],
-          "x": 1706.2253,
-          "y": 769.2512,
-          "direction": 2
-        },
-        "end": {
-          "tableId": "hYQsOkQ_jUFO0yPB3SMwa",
-          "columnIds": [
-            "ASWfbOUqSO9ZU6_dvBkdr"
-          ],
-          "x": 1838.4211,
-          "y": 937.1547,
-          "direction": 4
-        },
-        "meta": {
-          "updateAt": 1754290731305,
-          "createAt": 1754290731305
-        }
-      },
       "2U119K6mcJZmTcr21AdH7": {
         "id": "2U119K6mcJZmTcr21AdH7",
         "identification": false,
@@ -2076,8 +2014,8 @@
           "columnIds": [
             "E-xFy9--Bllgr1WONHJoe"
           ],
-          "x": 1267.2872,
-          "y": 1852.7162,
+          "x": 1312.2872,
+          "y": 1814.7162,
           "direction": 2
         },
         "end": {
@@ -2216,7 +2154,7 @@
           "columnIds": [
             "E-xFy9--Bllgr1WONHJoe"
           ],
-          "x": 1057.2872,
+          "x": 963.5372,
           "y": 1702.7162,
           "direction": 4
         },
@@ -2245,7 +2183,7 @@
             "BiderUKU6fxp0y8QcukEM"
           ],
           "x": 1150.762,
-          "y": 1411.9108,
+          "y": 1361.9108,
           "direction": 1
         },
         "end": {
@@ -2272,7 +2210,7 @@
           "columnIds": [
             "BiderUKU6fxp0y8QcukEM"
           ],
-          "x": 1428.262,
+          "x": 1335.762,
           "y": 1511.9108,
           "direction": 8
         },
@@ -2317,27 +2255,38 @@
           "updateAt": 1754292130417,
           "createAt": 1754292130417
         }
+      },
+      "YZr5yLlh93phj1l3r3BAY": {
+        "id": "YZr5yLlh93phj1l3r3BAY",
+        "identification": false,
+        "relationshipType": 16,
+        "startRelationshipType": 2,
+        "start": {
+          "tableId": "D-Rb2sNjpk0YacoJTRVdK",
+          "columnIds": [
+            "teo1Mv1wYgKO8-7zwxC4n"
+          ],
+          "x": 970.8834,
+          "y": 2203.568,
+          "direction": 4
+        },
+        "end": {
+          "tableId": "qRUdZZ0mToHT-_20zMDjK",
+          "columnIds": [
+            "fP7eV5JMjJsckudSiYifa"
+          ],
+          "x": 1079.7872,
+          "y": 1926.7162,
+          "direction": 8
+        },
+        "meta": {
+          "updateAt": 1754822670014,
+          "createAt": 1754822670014
+        }
       }
     },
     "indexEntities": {},
     "indexColumnEntities": {},
-    "memoEntities": {
-      "cvEZkyykFRNnYaIWY_ETq": {
-        "id": "cvEZkyykFRNnYaIWY_ETq",
-        "value": "",
-        "ui": {
-          "x": 411,
-          "y": 669.0005,
-          "zIndex": 246,
-          "width": 116,
-          "height": 100,
-          "color": ""
-        },
-        "meta": {
-          "updateAt": 1754289963418,
-          "createAt": 1754289963418
-        }
-      }
-    }
+    "memoEntities": {}
   }
 }

--- a/src/apis/pubbles/dto/create-pubbles.input.ts
+++ b/src/apis/pubbles/dto/create-pubbles.input.ts
@@ -1,4 +1,5 @@
 export class CreatePubbleInput {
   title: string;
   content: string;
+  pubbleCategoryId: string;
 }

--- a/src/apis/pubbles/entities/pubble.entity.ts
+++ b/src/apis/pubbles/entities/pubble.entity.ts
@@ -1,3 +1,7 @@
+import {
+  PubbleCategory,
+  pubbleCategory,
+} from 'src/apis/pubblesCategories/entities/pubbleCategory.entity';
 import { User } from 'src/apis/users/entities/user.entity';
 import {
   Column,
@@ -31,4 +35,7 @@ export class Pubble {
 
   @ManyToOne(() => User)
   user: User;
+
+  @ManyToOne(() => PubbleCategory)
+  pubbleCategory: PubbleCategory;
 }

--- a/src/apis/pubbles/entities/pubble.entity.ts
+++ b/src/apis/pubbles/entities/pubble.entity.ts
@@ -1,7 +1,4 @@
-import {
-  PubbleCategory,
-  pubbleCategory,
-} from 'src/apis/pubblesCategories/entities/pubbleCategory.entity';
+import { PubbleCategory } from 'src/apis/pubblesCategories/entities/pubbleCategory.entity';
 import { User } from 'src/apis/users/entities/user.entity';
 import {
   Column,

--- a/src/apis/pubbles/interfaces/pubbles.interface.ts
+++ b/src/apis/pubbles/interfaces/pubbles.interface.ts
@@ -23,3 +23,7 @@ export interface IPubblesServiceUpdatePartial {
   id: string;
   updatePartialPubbleInput: UpdatePartialPubbleInput;
 }
+
+export interface IPubbleServiceFindByCategory {
+  pubbleCategoryId: string;
+}

--- a/src/apis/pubbles/pubbles.service.ts
+++ b/src/apis/pubbles/pubbles.service.ts
@@ -18,8 +18,11 @@ export class PubblesService {
   ) {}
 
   async create({ createPubbleInput }: IPubblesServiceCreate): Promise<Pubble> {
-    const pubble = this.pubblesRepository.create(createPubbleInput);
-    return await this.pubblesRepository.save(pubble);
+    const { pubbleCategoryId, ...pubbleInput } = createPubbleInput;
+    return await this.pubblesRepository.save({
+      ...pubbleInput,
+      pubbleCategory: { id: pubbleCategoryId },
+    });
   }
 
   async findAll(): Promise<Pubble[]> {

--- a/src/apis/pubbles/pubbles.service.ts
+++ b/src/apis/pubbles/pubbles.service.ts
@@ -19,20 +19,25 @@ export class PubblesService {
 
   async create({ createPubbleInput }: IPubblesServiceCreate): Promise<Pubble> {
     const { pubbleCategoryId, ...pubbleInput } = createPubbleInput;
-    return await this.pubblesRepository.save({
+    const saved = await this.pubblesRepository.save({
       ...pubbleInput,
       pubbleCategory: { id: pubbleCategoryId },
     });
+    return this.findOne({ id: saved.id });
   }
 
   async findAll(): Promise<Pubble[]> {
     return await this.pubblesRepository.find({
       order: { created_at: 'DESC' },
+      relations: ['pubbleCategory'],
     });
   }
 
   async findOne({ id }: IPubblesServiceFindOne): Promise<Pubble> {
-    const pubble = await this.pubblesRepository.findOne({ where: { id } });
+    const pubble = await this.pubblesRepository.findOne({
+      where: { id },
+      relations: ['pubbleCategory'],
+    });
     if (!pubble)
       throw new UnprocessableEntityException(`Pubble with ID ${id} not found`);
     return pubble;

--- a/src/apis/pubbles/pubbles.service.ts
+++ b/src/apis/pubbles/pubbles.service.ts
@@ -3,6 +3,7 @@ import { Repository } from 'typeorm';
 import { InjectRepository } from '@nestjs/typeorm';
 import { Pubble } from './entities/pubble.entity';
 import {
+  IPubbleServiceFindByCategory,
   IPubblesServiceCreate,
   IPubblesServiceDelete,
   IPubblesServiceFindOne,
@@ -41,6 +42,11 @@ export class PubblesService {
     if (!pubble)
       throw new UnprocessableEntityException(`Pubble with ID ${id} not found`);
     return pubble;
+  }
+  async findByCategory({ pubbleCategoryId }: IPubbleServiceFindByCategory) {
+    return await this.pubblesRepository.find({
+      where: { pubbleCategory: { id: pubbleCategoryId } },
+    });
   }
 
   async update({

--- a/src/apis/pubblesCategories/entities/pubbleCategory.entity.ts
+++ b/src/apis/pubblesCategories/entities/pubbleCategory.entity.ts
@@ -1,7 +1,7 @@
 import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
 
 @Entity()
-export class pubbleCategory {
+export class PubbleCategory {
   @PrimaryGeneratedColumn('uuid')
   id: string;
 

--- a/src/apis/pubblesCategories/entities/pubbleCategory.entity.ts
+++ b/src/apis/pubblesCategories/entities/pubbleCategory.entity.ts
@@ -1,0 +1,10 @@
+import { Column, Entity, PrimaryGeneratedColumn } from 'typeorm';
+
+@Entity()
+export class pubbleCategory {
+  @PrimaryGeneratedColumn('uuid')
+  id: string;
+
+  @Column()
+  name: string;
+}

--- a/src/apis/pubblesCategories/interfaces/pubblesCategories.interface.ts
+++ b/src/apis/pubblesCategories/interfaces/pubblesCategories.interface.ts
@@ -1,3 +1,11 @@
 export interface IPubblesCategoriesServiceFindOne {
   id: string;
 }
+
+export interface IPubblesCategoriesServiceCreate {
+  name: string;
+}
+
+export interface IPubblesCategoriesServiceFindOneByName {
+  name: string;
+}

--- a/src/apis/pubblesCategories/interfaces/pubblesCategories.interface.ts
+++ b/src/apis/pubblesCategories/interfaces/pubblesCategories.interface.ts
@@ -1,0 +1,3 @@
+export interface IPubblesCategoriesServiceFindOne {
+  id: string;
+}

--- a/src/apis/pubblesCategories/pubblesCategories.controller.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.controller.ts
@@ -1,4 +1,12 @@
-import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  Param,
+  Post,
+  Put,
+} from '@nestjs/common';
 import { PubblesCategoriesService } from './pubblesCategories.service';
 import { PubbleCategory } from './entities/pubbleCategory.entity';
 
@@ -21,5 +29,13 @@ export class PubblesCategoriesController {
   @Delete('/:id')
   delete(@Param('id') id: string) {
     return this.pubblesCategoriesService.delete({ id });
+  }
+
+  @Put('/:id')
+  update(
+    @Param('id') id: string, //
+    @Body('name') name: string,
+  ) {
+    return this.pubblesCategoriesService.update({ id, name });
   }
 }

--- a/src/apis/pubblesCategories/pubblesCategories.controller.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.controller.ts
@@ -1,4 +1,4 @@
-import { Body, Controller, Get, Post } from '@nestjs/common';
+import { Body, Controller, Delete, Get, Param, Post } from '@nestjs/common';
 import { PubblesCategoriesService } from './pubblesCategories.service';
 import { PubbleCategory } from './entities/pubbleCategory.entity';
 
@@ -16,5 +16,10 @@ export class PubblesCategoriesController {
   @Get()
   findAll() {
     return this.pubblesCategoriesService.findAll();
+  }
+
+  @Delete('/:id')
+  delete(@Param('id') id: string) {
+    return this.pubblesCategoriesService.delete({ id });
   }
 }

--- a/src/apis/pubblesCategories/pubblesCategories.controller.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.controller.ts
@@ -1,0 +1,4 @@
+import { Controller } from '@nestjs/common';
+
+@Controller()
+export class pubblesCategoriesController {}

--- a/src/apis/pubblesCategories/pubblesCategories.controller.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.controller.ts
@@ -1,4 +1,20 @@
-import { Controller } from '@nestjs/common';
+import { Body, Controller, Get, Post } from '@nestjs/common';
+import { PubblesCategoriesService } from './pubblesCategories.service';
+import { PubbleCategory } from './entities/pubbleCategory.entity';
 
-@Controller()
-export class pubblesCategoriesController {}
+@Controller('pubblesCategories')
+export class PubblesCategoriesController {
+  constructor(
+    private readonly pubblesCategoriesService: PubblesCategoriesService, //
+  ) {}
+
+  @Post()
+  create(@Body('name') name: string): Promise<PubbleCategory> {
+    return this.pubblesCategoriesService.create({ name });
+  }
+
+  @Get()
+  findAll() {
+    return this.pubblesCategoriesService.findAll();
+  }
+}

--- a/src/apis/pubblesCategories/pubblesCategories.module.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.module.ts
@@ -3,14 +3,20 @@ import { TypeOrmModule } from '@nestjs/typeorm';
 import { PubbleCategory } from './entities/pubbleCategory.entity';
 import { PubblesCategoriesController } from './pubblesCategories.controller';
 import { PubblesCategoriesService } from './pubblesCategories.service';
+import { Pubble } from '../pubbles/entities/pubble.entity';
+import { PubblesService } from '../pubbles/pubbles.service';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       PubbleCategory, //
+      Pubble,
     ]),
   ],
   controllers: [PubblesCategoriesController],
-  providers: [PubblesCategoriesService],
+  providers: [
+    PubblesCategoriesService, //
+    PubblesService,
+  ],
 })
 export class PubblesCategoriesModule {}

--- a/src/apis/pubblesCategories/pubblesCategories.module.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.module.ts
@@ -2,12 +2,12 @@ import { Module } from '@nestjs/common';
 import { pubblesCategoriesController } from './pubblesCategories.controller';
 import { pubblesCategoriesService } from './pubblesCategories.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
-import { pubbleCategory } from './entities/pubbleCategory.entity';
+import { PubbleCategory } from './entities/pubbleCategory.entity';
 
 @Module({
   imports: [
     TypeOrmModule.forFeature([
-      pubbleCategory, //
+      PubbleCategory, //
     ]),
   ],
   controllers: [pubblesCategoriesController],

--- a/src/apis/pubblesCategories/pubblesCategories.module.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.module.ts
@@ -1,0 +1,16 @@
+import { Module } from '@nestjs/common';
+import { pubblesCategoriesController } from './pubblesCategories.controller';
+import { pubblesCategoriesService } from './pubblesCategories.service';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { pubbleCategory } from './entities/pubbleCategory.entity';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([
+      pubbleCategory, //
+    ]),
+  ],
+  controllers: [pubblesCategoriesController],
+  providers: [pubblesCategoriesService],
+})
+export class pubblesCategoriesModule {}

--- a/src/apis/pubblesCategories/pubblesCategories.module.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.module.ts
@@ -1,8 +1,8 @@
 import { Module } from '@nestjs/common';
-import { pubblesCategoriesController } from './pubblesCategories.controller';
-import { pubblesCategoriesService } from './pubblesCategories.service';
 import { TypeOrmModule } from '@nestjs/typeorm';
 import { PubbleCategory } from './entities/pubbleCategory.entity';
+import { PubblesCategoriesController } from './pubblesCategories.controller';
+import { PubblesCategoriesService } from './pubblesCategories.service';
 
 @Module({
   imports: [
@@ -10,7 +10,7 @@ import { PubbleCategory } from './entities/pubbleCategory.entity';
       PubbleCategory, //
     ]),
   ],
-  controllers: [pubblesCategoriesController],
-  providers: [pubblesCategoriesService],
+  controllers: [PubblesCategoriesController],
+  providers: [PubblesCategoriesService],
 })
-export class pubblesCategoriesModule {}
+export class PubblesCategoriesModule {}

--- a/src/apis/pubblesCategories/pubblesCategories.service.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.service.ts
@@ -1,4 +1,17 @@
 import { Injectable } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { PubbleCategory } from './entities/pubbleCategory.entity';
+import { Repository } from 'typeorm';
+import { IPubblesCategoriesServiceFindOne } from './interfaces/pubblesCategories.interface';
 
 @Injectable()
-export class pubblesCategoriesService {}
+export class pubblesCategoriesService {
+  constructor(
+    @InjectRepository(PubbleCategory)
+    private readonly pubblesCategoriesRepository: Repository<PubbleCategory>, //
+  ) {}
+
+  async findOne({ id }: IPubblesCategoriesServiceFindOne) {
+    return await this.pubblesCategoriesRepository.findOne({ where: { id } });
+  }
+}

--- a/src/apis/pubblesCategories/pubblesCategories.service.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.service.ts
@@ -1,11 +1,15 @@
-import { Injectable } from '@nestjs/common';
+import { Injectable, UnprocessableEntityException } from '@nestjs/common';
 import { InjectRepository } from '@nestjs/typeorm';
 import { PubbleCategory } from './entities/pubbleCategory.entity';
 import { Repository } from 'typeorm';
-import { IPubblesCategoriesServiceFindOne } from './interfaces/pubblesCategories.interface';
+import {
+  IPubblesCategoriesServiceCreate,
+  IPubblesCategoriesServiceFindOne,
+  IPubblesCategoriesServiceFindOneByName,
+} from './interfaces/pubblesCategories.interface';
 
 @Injectable()
-export class pubblesCategoriesService {
+export class PubblesCategoriesService {
   constructor(
     @InjectRepository(PubbleCategory)
     private readonly pubblesCategoriesRepository: Repository<PubbleCategory>, //
@@ -13,5 +17,24 @@ export class pubblesCategoriesService {
 
   async findOne({ id }: IPubblesCategoriesServiceFindOne) {
     return await this.pubblesCategoriesRepository.findOne({ where: { id } });
+  }
+
+  async findAll() {
+    return await this.pubblesCategoriesRepository.find();
+  }
+
+  async findOneByName({ name }: IPubblesCategoriesServiceFindOneByName) {
+    return await this.pubblesCategoriesRepository.findOne({ where: { name } });
+  }
+
+  async create({ name }: IPubblesCategoriesServiceCreate) {
+    let pubbleCategory = await this.findOneByName({ name });
+    if (pubbleCategory)
+      throw new UnprocessableEntityException('this category is already exist');
+    pubbleCategory = await this.pubblesCategoriesRepository.save({ name });
+    return {
+      id: pubbleCategory.id,
+      name: pubbleCategory.name,
+    };
   }
 }

--- a/src/apis/pubblesCategories/pubblesCategories.service.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.service.ts
@@ -7,12 +7,14 @@ import {
   IPubblesCategoriesServiceFindOne,
   IPubblesCategoriesServiceFindOneByName,
 } from './interfaces/pubblesCategories.interface';
+import { PubblesService } from '../pubbles/pubbles.service';
 
 @Injectable()
 export class PubblesCategoriesService {
   constructor(
     @InjectRepository(PubbleCategory)
     private readonly pubblesCategoriesRepository: Repository<PubbleCategory>, //
+    private readonly pubblesService: PubblesService,
   ) {}
 
   async findOne({ id }: IPubblesCategoriesServiceFindOne) {
@@ -36,5 +38,20 @@ export class PubblesCategoriesService {
       id: pubbleCategory.id,
       name: pubbleCategory.name,
     };
+  }
+
+  async delete({ id }: { id: string }) {
+    const pubbles = await this.pubblesService.findByCategory({
+      pubbleCategoryId: id,
+    });
+    if (pubbles)
+      throw new UnprocessableEntityException(
+        `there are pubbles with categoryId ${id}`,
+      );
+    const category = await this.findOne({ id });
+    if (!category)
+      throw new UnprocessableEntityException('this category is not exist');
+    const result = await this.pubblesCategoriesRepository.delete(id);
+    return result.affected ? true : false;
   }
 }

--- a/src/apis/pubblesCategories/pubblesCategories.service.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.service.ts
@@ -40,6 +40,14 @@ export class PubblesCategoriesService {
     };
   }
 
+  async update({ id, name }: { id: string; name: string }) {
+    const category = await this.findOne({ id });
+    if (!category)
+      throw new UnprocessableEntityException('this category is not exist');
+    Object.assign(category, { name });
+    return this.pubblesCategoriesRepository.save(category);
+  }
+
   async delete({ id }: { id: string }) {
     const pubbles = await this.pubblesService.findByCategory({
       pubbleCategoryId: id,

--- a/src/apis/pubblesCategories/pubblesCategories.service.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.service.ts
@@ -1,0 +1,4 @@
+import { Injectable } from '@nestjs/common';
+
+@Injectable()
+export class pubblesCategoriesService {}

--- a/src/app.module.ts
+++ b/src/app.module.ts
@@ -4,11 +4,13 @@ import { PubblesModule } from './apis/pubbles/pubbles.module';
 import { AuthModule } from './apis/auth/auth.module';
 import { ConfigModule } from '@nestjs/config';
 import { UsersModule } from './apis/users/users.module';
+import { PubblesCategoriesModule } from './apis/pubblesCategories/pubblesCategories.module';
 
 @Module({
   imports: [
     AuthModule,
     PubblesModule,
+    PubblesCategoriesModule,
     UsersModule,
     ConfigModule.forRoot(),
     TypeOrmModule.forRoot({


### PR DESCRIPTION
## 📝 What Did You Do
- [x] pubbleCategory 엔티티 (pubble 엔티티와 연결)
- [x] pubblesCategories 기본 CRUD

## 🔍 How To Test

## 📜 ETC
- pubbles 생성 API 호출 시 인자 헷갈리지 말기 (특히 **pubbleCategoryId**)
```json
{
  "title": "제목",
  "content": "내용",
  "pubbleCategoryId": "카테고리"
}
```
- 권한 관련
  - 나중에 Admin만 카테고리 API 사용 가능하도록 Guard로 막기 
  - 반면 나중에 만들 태그 API는 어떤 사용자든지 사용 가능
  - 현재는 모두 접근 가능
- 카테고리 삭제 관련
  - 영구 삭제(?) 나중에 실수로 삭제할 수도 있으니 이거에 대해서는 더 찾아봐야할듯
  - 현재는 영구 삭제