### PR TITLE
Feat: 퍼블 생성 시 유저 정보도 같이 저장되도록 수정

### DIFF
--- a/src/apis/pubbles/entities/pubble.entity.ts
+++ b/src/apis/pubbles/entities/pubble.entity.ts
@@ -33,7 +33,7 @@ export class Pubble {
   deleted_at: Date;
 
   @ManyToOne(() => User)
-  user: User;
+  author: User;
 
   @ManyToOne(() => PubbleCategory)
   pubbleCategory: PubbleCategory;

--- a/src/apis/pubbles/interfaces/pubbles.interface.ts
+++ b/src/apis/pubbles/interfaces/pubbles.interface.ts
@@ -4,6 +4,7 @@ import { UpdatePartialPubbleInput } from '../dto/updatePartial-pubbles.input';
 
 export interface IPubblesServiceCreate {
   createPubbleInput: CreatePubbleInput;
+  id: string;
 }
 
 export interface IPubblesServiceDelete {

--- a/src/apis/pubbles/pubbles.controller.ts
+++ b/src/apis/pubbles/pubbles.controller.ts
@@ -7,12 +7,17 @@ import {
   Patch,
   Post,
   Put,
+  Req,
+  UnprocessableEntityException,
+  UseGuards,
 } from '@nestjs/common';
 import { CreatePubbleInput } from './dto/create-pubbles.input';
 import { Pubble } from './entities/pubble.entity';
 import { PubblesService } from './pubbles.service';
 import { UpdatePartialPubbleInput } from './dto/updatePartial-pubbles.input';
 import { UpdatePubbleInput } from './dto/update-pupbbles.input';
+import { AuthGuard } from '@nestjs/passport';
+import { IAuthUser } from 'src/commons/interfaces/context';
 
 @Controller('pubbles')
 export class PubblesController {
@@ -33,10 +38,13 @@ export class PubblesController {
   }
 
   @Post()
+  @UseGuards(AuthGuard('access'))
   create(
     @Body() createPubbleInput: CreatePubbleInput, //
+    @Req() req: Request & IAuthUser, //
   ) {
-    return this.pubblesService.create({ createPubbleInput });
+    if (!req.user) throw new UnprocessableEntityException();
+    return this.pubblesService.create({ createPubbleInput, id: req.user.id });
   }
 
   @Put(':id')

--- a/src/apis/pubbles/pubbles.controller.ts
+++ b/src/apis/pubbles/pubbles.controller.ts
@@ -41,18 +41,22 @@ export class PubblesController {
   @UseGuards(AuthGuard('access'))
   create(
     @Body() createPubbleInput: CreatePubbleInput, //
-    @Req() req: Request & IAuthUser, //
+    @Req() req: Request & IAuthUser,
   ) {
     if (!req.user) throw new UnprocessableEntityException();
     return this.pubblesService.create({ createPubbleInput, id: req.user.id });
   }
 
   @Put(':id')
+  @UseGuards(AuthGuard('access'))
   update(
     @Param('id') id: string, //
     @Body() updatePubbleInput: UpdatePubbleInput,
   ): Promise<Pubble> {
-    return this.pubblesService.update({ id, updatePubbleInput });
+    return this.pubblesService.update({
+      id,
+      updatePubbleInput,
+    });
   }
 
   @Patch(':id')

--- a/src/apis/pubbles/pubbles.module.ts
+++ b/src/apis/pubbles/pubbles.module.ts
@@ -5,17 +5,21 @@ import { Pubble } from './entities/pubble.entity';
 import { PubblesController } from './pubbles.controller';
 import { PubbleTag } from '../pubblesTags/entities/pubbleTag.entity';
 import { PubblesTagsService } from '../pubblesTags/pubblesTags.service';
+import { User } from '../users/entities/user.entity';
+import { UsersService } from '../users/users.service';
 @Module({
   imports: [
     TypeOrmModule.forFeature([
       Pubble, //
       PubbleTag,
+      User,
     ]),
   ],
   controllers: [PubblesController],
   providers: [
     PubblesService, //
     PubblesTagsService,
+    UsersService,
   ],
 })
 export class PubblesModule {}

--- a/src/apis/pubbles/pubbles.service.ts
+++ b/src/apis/pubbles/pubbles.service.ts
@@ -12,6 +12,7 @@ import {
 } from './interfaces/pubbles.interface';
 import { PubblesTagsService } from '../pubblesTags/pubblesTags.service';
 import { PubbleTag } from '../pubblesTags/entities/pubbleTag.entity';
+import { UsersService } from '../users/users.service';
 
 @Injectable()
 export class PubblesService {
@@ -19,11 +20,19 @@ export class PubblesService {
     @InjectRepository(Pubble)
     private readonly pubblesRepository: Repository<Pubble>, //
     private readonly pubblesTagsService: PubblesTagsService,
+    private readonly usersService: UsersService,
   ) {}
 
-  async create({ createPubbleInput }: IPubblesServiceCreate): Promise<Pubble> {
+  async create({
+    createPubbleInput,
+    id,
+  }: IPubblesServiceCreate): Promise<Pubble> {
     const { pubbleCategoryId, pubblesTags, ...pubbleInput } = createPubbleInput;
 
+    // user
+    const user = await this.usersService.findOne({ id });
+
+    // tags
     const tagNames = pubblesTags.map((el) => el.replace('#', ''));
     const prevTags = await this.pubblesTagsService.findByNames({ tagNames });
     const temp: { name: string }[] = [];
@@ -38,6 +47,7 @@ export class PubblesService {
       ...pubbleInput,
       pubbleCategory: { id: pubbleCategoryId },
       pubblesTags: tags,
+      author: user,
     });
   }
 

--- a/src/apis/pubbles/pubbles.service.ts
+++ b/src/apis/pubbles/pubbles.service.ts
@@ -54,14 +54,14 @@ export class PubblesService {
   async findAll(): Promise<Pubble[]> {
     return await this.pubblesRepository.find({
       order: { created_at: 'DESC' },
-      relations: ['pubbleCategory'],
+      relations: ['pubbleCategory', 'author', 'pubblesTags'],
     });
   }
 
   async findOne({ id }: IPubblesServiceFindOne): Promise<Pubble> {
     const pubble = await this.pubblesRepository.findOne({
       where: { id },
-      relations: ['pubbleCategory'],
+      relations: ['pubbleCategory', 'author', 'pubblesTags'],
     });
     if (!pubble)
       throw new UnprocessableEntityException(`Pubble with ID ${id} not found`);

--- a/src/apis/pubbles/pubbles.service.ts
+++ b/src/apis/pubbles/pubbles.service.ts
@@ -81,6 +81,7 @@ export class PubblesService {
     const pubble = await this.findOne({ id });
     const { pubblesTags, ...temp } = updatePubbleInput;
 
+    // tags
     let tags: PubbleTag[];
     if (pubblesTags)
       tags = await this.pubblesTagsService.findByNames({

--- a/src/apis/pubblesCategories/pubblesCategories.module.ts
+++ b/src/apis/pubblesCategories/pubblesCategories.module.ts
@@ -7,6 +7,7 @@ import { Pubble } from '../pubbles/entities/pubble.entity';
 import { PubblesService } from '../pubbles/pubbles.service';
 import { PubblesTagsService } from '../pubblesTags/pubblesTags.service';
 import { PubbleTag } from '../pubblesTags/entities/pubbleTag.entity';
+import { UsersModule } from '../users/users.module';
 
 @Module({
   imports: [
@@ -15,6 +16,7 @@ import { PubbleTag } from '../pubblesTags/entities/pubbleTag.entity';
       Pubble,
       PubbleTag,
     ]),
+    UsersModule,
   ],
   controllers: [PubblesCategoriesController],
   providers: [

--- a/src/apis/users/users.module.ts
+++ b/src/apis/users/users.module.ts
@@ -12,5 +12,6 @@ import { UsersService } from './users.service';
   ],
   controllers: [UsersController],
   providers: [UsersService],
+  exports: [UsersService],
 })
 export class UsersModule {}

--- a/test-frontend.html
+++ b/test-frontend.html
@@ -16,13 +16,13 @@
       <button>카카오 로그인</button>
     </a>
 
-    <a href="https://publit2-image-531771359911.asia-northeast1.run.app/auth/login-google/auth/login-google">
+    <a href="https://publit2-image-531771359911.asia-northeast1.run.app/auth/login-google">
       <button>구글 로그인 배포</button>
     </a>
-    <a href="https://publit2-image-531771359911.asia-northeast1.run.app/auth/login-google/auth/login-naver">
+    <a href="https://publit2-image-531771359911.asia-northeast1.run.app/auth/login-naver">
       <button>네이버 로그인 배포</button>
     </a>
-    <a href="https://publit2-image-531771359911.asia-northeast1.run.app/auth/login-google/auth/login-kakao">
+    <a href="https://publit2-image-531771359911.asia-northeast1.run.app/auth/login-kakao">
       <button>카카오 로그인 배포</button>
     </a>
 


### PR DESCRIPTION
## 📝 What Did You Do
- [x] 퍼블 생성 시 access Auth 가드를 통과하여 유저 정보를 받아와 author 필드에 저장
- [x] 조회 시에도 게시글 저자 id 보이도록 수정

## 🔍 How To Test
1. 소설 로그인을 통해 refreshToken 받기
2. API 호출 예시
```bash
curl -X POST "https://publit2-image-531771359911.asia-northeast1.run.app/pubbles" \
-H "Content-Type: application/json" \
-H "Authorization: Bearer your_token_here" \
-d '{
  "title": "제목입니다.",
  "content": "내용입니다.",
  "pubbleCategoryId": "379763de-91f7-4490-ad93-70555043e1d4",
  "pubblesTags": ["#재밌어", "#일상"]
}'
```
3. 반환 예시
```json
{
  "success": true,
  "code": 200,
  "message": "successful response",
  "data": {
    "title": "제목입니다.",
    "content": "내용입니다.",
    "pubbleCategory": {
      "id": "379763de-91f7-4490-ad93-70555043e1d4"
    },
    "pubblesTags": [
      {
        "id": "a94c13d1-2470-4766-8423-d34673c77900"
      },
      {
        "id": "3bf554c4-1635-4dbf-a388-fbe0997c084f"
      }
    ],
    "author": {
      "id": "b1fd908d-43cf-4ddc-b6e1-e6f75a9ff111",
      "username": "user",
      "email": "jogyuyeonn@gmail.com",
      "profile_img": null,
      "created_at": "2025-08-13T03:54:43.517Z"
    },
    "id": "77a783f4-cc19-4a16-9eff-a9ba1f0fbc38",
    "created_at": "2025-08-13T04:27:33.080Z",
    "updated_at": "2025-08-13T04:27:33.080Z",
    "deleted_at": null
  }
}
```