### PR TITLE
Feat: 임시저장 API

### DIFF
--- a/data.erd.json
+++ b/data.erd.json
@@ -4,8 +4,8 @@
   "settings": {
     "width": 3000,
     "height": 3000,
-    "scrollTop": -1205.2103,
-    "scrollLeft": -1187.4055,
+    "scrollTop": -992.5414,
+    "scrollLeft": -899.9056,
     "zoomLevel": 0.72,
     "show": 431,
     "database": 4,

--- a/src/apis/pubbles/dto/create-pubbles.input.ts
+++ b/src/apis/pubbles/dto/create-pubbles.input.ts
@@ -2,6 +2,7 @@ export class CreatePubbleInput {
   title: string;
   content: string;
   fileNames: string | null;
+  isDraft: boolean;
   pubbleCategoryId: string;
   pubblesTags: string[];
 }

--- a/src/apis/pubbles/dto/update-pupbbles.input.ts
+++ b/src/apis/pubbles/dto/update-pupbbles.input.ts
@@ -2,6 +2,7 @@ export class UpdatePubbleInput {
   title: string;
   content: string;
   fileNames: string | null;
+  isDraft: boolean;
   pubbleCategoryId: string;
   pubblesTags: string[];
 }

--- a/src/apis/pubbles/entities/pubble.entity.ts
+++ b/src/apis/pubbles/entities/pubble.entity.ts
@@ -32,7 +32,7 @@ export class Pubble {
   @Column({ default: 0 })
   likeCount: number;
 
-  @Column()
+  @Column({ default: false })
   isDraft: boolean;
 
   @CreateDateColumn()

--- a/src/apis/pubbles/entities/pubble.entity.ts
+++ b/src/apis/pubbles/entities/pubble.entity.ts
@@ -32,6 +32,9 @@ export class Pubble {
   @Column({ default: 0 })
   likeCount: number;
 
+  @Column()
+  isDraft: boolean;
+
   @CreateDateColumn()
   created_at: Date;
 

--- a/src/apis/pubbles/interfaces/pubbles.interface.ts
+++ b/src/apis/pubbles/interfaces/pubbles.interface.ts
@@ -28,3 +28,9 @@ export interface IPubblesServiceUpdatePartial {
 export interface IPubbleServiceFindByCategory {
   pubbleCategoryId: string;
 }
+
+export interface IPubblesServiceUpdateDraft {
+  id: string;
+  isDraft: boolean;
+  userId: string;
+}

--- a/src/apis/pubbles/pubbles.controller.ts
+++ b/src/apis/pubbles/pubbles.controller.ts
@@ -69,6 +69,34 @@ export class PubblesController {
     return this.pubblesService.updatePartial({ id, updatePartialPubbleInput });
   }
 
+  @Patch(':id/draft')
+  @UseGuards(AuthGuard('access'))
+  updateSaveDraft(
+    @Param('id') id: string, //
+    @Req() req: Request & IAuthUser,
+  ) {
+    if (!req.user) throw new UnprocessableEntityException();
+    return this.pubblesService.updateDraft({
+      id,
+      isDraft: false,
+      userId: req.user.id,
+    });
+  }
+
+  @Patch(':id/draft')
+  @UseGuards(AuthGuard('access'))
+  updatePublishDraft(
+    @Param('id') id: string, //
+    @Req() req: Request & IAuthUser,
+  ) {
+    if (!req.user) throw new UnprocessableEntityException();
+    return this.pubblesService.updateDraft({
+      id,
+      isDraft: true,
+      userId: req.user.id,
+    });
+  }
+
   @Delete(':id')
   delete(@Param('id') id: string) {
     return this.pubblesService.delete({ id });

--- a/src/apis/pubbles/pubbles.controller.ts
+++ b/src/apis/pubbles/pubbles.controller.ts
@@ -69,7 +69,7 @@ export class PubblesController {
     return this.pubblesService.updatePartial({ id, updatePartialPubbleInput });
   }
 
-  @Patch(':id/draft')
+  @Patch(':id/publish-draft')
   @UseGuards(AuthGuard('access'))
   updateSaveDraft(
     @Param('id') id: string, //
@@ -83,7 +83,7 @@ export class PubblesController {
     });
   }
 
-  @Patch(':id/draft')
+  @Patch(':id/save-draft')
   @UseGuards(AuthGuard('access'))
   updatePublishDraft(
     @Param('id') id: string, //

--- a/src/apis/pubbles/pubbles.service.ts
+++ b/src/apis/pubbles/pubbles.service.ts
@@ -8,6 +8,7 @@ import {
   IPubblesServiceDelete,
   IPubblesServiceFindOne,
   IPubblesServiceUpdate,
+  IPubblesServiceUpdateDraft,
   IPubblesServiceUpdatePartial,
 } from './interfaces/pubbles.interface';
 import { PubblesTagsService } from '../pubblesTags/pubblesTags.service';
@@ -110,6 +111,20 @@ export class PubblesService {
 
     Object.assign(pubble, { ...temp, tags });
     return await this.pubblesRepository.save(pubble);
+  }
+
+  async updateDraft({ id, isDraft, userId }: IPubblesServiceUpdateDraft) {
+    const pubble = await this.findOne({ id });
+    if (pubble.author.id !== userId)
+      throw new UnprocessableEntityException(
+        'You are not the author of this pubble',
+      );
+    if (pubble.isDraft == isDraft)
+      throw new UnprocessableEntityException(
+        'This pubble is already in the desired draft state',
+      );
+    await this.pubblesRepository.update(id, { isDraft });
+    return { success: true };
   }
 
   async delete({ id }: IPubblesServiceDelete): Promise<boolean> {


### PR DESCRIPTION
## 📝 What Did You Do
- [x] 임시저장 API 원래 pubble 엔티티와 통일, 단 isDraft 필드를 추가하여 관리
- [x] 임시저장 상태 바꾸기 API 구현 

## 🔍 How To Test
1. 로그인
2. server-url/pubbles/:id/publish-draft
3. server-url/pubbles/:id/save-draft

## 📜 ETC
- 현재는 게시된 퍼블과 저장된 퍼블이 통합되어있음
- 나중에 버전관리하고싶다면 따로 테이블을 관리해야함